### PR TITLE
added support for focus.de

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -53,6 +53,17 @@
       "css": [
         "css/overlay.css"
       ]
+    },
+    {
+      "matches": [
+        "*://www.focus.de/*"
+      ],
+      "js": [
+        "scripts/blocker_focus.js"
+      ],
+      "css": [
+        "css/overlay.css"
+      ]
     }
   ]
 }

--- a/app/scripts/blocker_focus.js
+++ b/app/scripts/blocker_focus.js
@@ -1,0 +1,25 @@
+console.log("#### AfD CONTENT-BLOCKER ####");
+
+import { Blocker } from "./blocker_general";
+
+let blocker = new Blocker([
+    {
+        selector: 'div.teaser',
+        type: 'big'
+    },
+    {
+        selector: 'div.promo',
+        type: 'big'
+    },
+    {
+        selector: 'li.teaser',
+        type: 'big'
+    },
+    {
+        selector: 'div.img',
+        type: 'big'
+    },
+]);
+
+blocker.modifyContent();
+

--- a/app/scripts/blocker_focus.js
+++ b/app/scripts/blocker_focus.js
@@ -21,5 +21,5 @@ let blocker = new Blocker([
     },
 ]);
 
-blocker.modifyContent();
-
+blocker.modifyContent([document]);
+blocker.watchPageForMutations();


### PR DESCRIPTION
This schould block most things except of lists without classnames.
(lists like this:
<ul>
<li>
<a href="..." title="..."><span class="date">12:58 Uhr</span>...</a>
</li>
<li></li>...
/ul>)

look below for the unformated code I want to show