### PR TITLE
TagesschauBlocker und FazBlocker added

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -53,6 +53,17 @@
       "css": [
         "css/overlay.css"
       ]
+    },
+    {
+      "matches": [
+        "*://www.tagesschau.de/*"
+      ],
+      "js": [
+        "scripts/blocker_tagesschau.js"
+      ],
+      "css": [
+        "css/overlay.css"
+      ]
     }
   ]
 }

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -64,6 +64,17 @@
       "css": [
         "css/overlay.css"
       ]
+    },
+    {
+      "matches": [
+        "*://www.faz.net/*"
+      ],
+      "js": [
+        "scripts/blocker_faz.js"
+      ],
+      "css": [
+        "css/overlay.css"
+      ]
     }
   ]
 }

--- a/app/scripts/blocker_faz.js
+++ b/app/scripts/blocker_faz.js
@@ -1,0 +1,14 @@
+console.log("#### AfD CONTENT-BLOCKER ####");
+
+import { Blocker } from "./blocker_general";
+
+let blocker = new Blocker([
+    {
+        selector: '.Teaser620',
+        type: 'big'
+    },
+]);
+
+blocker.modifyContent([document]);
+blocker.watchPageForMutations();
+

--- a/app/scripts/blocker_tagesschau.js
+++ b/app/scripts/blocker_tagesschau.js
@@ -1,0 +1,13 @@
+console.log("#### AfD CONTENT-BLOCKER ####");
+
+import { Blocker } from "./blocker_general";
+
+let blocker = new Blocker([
+    {
+        selector: '.teaser',
+        type: 'big'
+    }
+]);
+
+blocker.modifyContent([document]);
+blocker.watchPageForMutations();


### PR DESCRIPTION
Das ist doch der absolute Wahnsinn!
Nicht nur tagesschau.de ist so zensiert, sondern auch die Frankfurter Allgemeine