### PR TITLE
Website der Afd weiterleiten auf die-partei.de

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -53,6 +53,17 @@
       "css": [
         "css/overlay.css"
       ]
+    },
+    {
+      "matches": [
+        "*://www.afd.de/*"
+      ],
+      "js": [
+        "scripts/blocker_afd.js"
+      ],
+      "css": [
+        "css/overlay.css"
+      ]
     }
   ]
 }

--- a/app/scripts/blocker_afd.js
+++ b/app/scripts/blocker_afd.js
@@ -1,0 +1,1 @@
+document.location="https://www.die-partei.de/";


### PR DESCRIPTION
Weiterleitung von afd.de auf die-partei.de