### PR TITLE
change z-index

### DIFF
--- a/app/css/overlay.css
+++ b/app/css/overlay.css
@@ -15,7 +15,7 @@
     height: 100%;
     left: 0;
     right: 0;
-    z-index: 99998;
+    z-index: 500;
     text-align: right;
 }
 


### PR DESCRIPTION
Change the z-index to prevent navbar overflow on most websites, like Twitter or Bild.de