### PR TITLE
Add option for custom z-index and add blocker for WELT

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -91,6 +91,11 @@
       "matches": [ "*://www.nordbayern.de/*" ],
       "js": [ "scripts/blocker_nordbayern.js" ],
       "css": [ "css/overlay.css" ]
+    },
+    {
+      "matches": [ "*://www.welt.de/*" ],
+      "js": [ "scripts/blocker_welt.js" ],
+      "css": [ "css/overlay.css" ]
     }
   ]
 }

--- a/app/scripts/blocker_general.js
+++ b/app/scripts/blocker_general.js
@@ -87,7 +87,8 @@ export class Blocker {
                             {
                                 nodeConfigurations.push({
                                     element: ancestorTeaser,
-                                    type: this.selectorList[i].type
+                                    type: this.selectorList[i].type,
+                                    zIndex: this.selectorList[i].zIndex
                                 });
                             }
                             // Wrapper found
@@ -141,6 +142,9 @@ export function addBlocker(nodeConfigurations) {
                 overlay = overlayNode.cloneNode(true);
             } else {
                 overlay = overlaySmallNode.cloneNode(true);
+            }
+            if (nodeConfiguration.zIndex) {
+                overlay.style.zIndex = nodeConfiguration.zIndex;
             }
             nodeConfiguration.element.insertBefore(overlay, nodeConfiguration.element.firstChild);
         }

--- a/app/scripts/blocker_welt.js
+++ b/app/scripts/blocker_welt.js
@@ -1,0 +1,39 @@
+console.log("#### AfD CONTENT-BLOCKER ####");
+
+import { Blocker } from "./blocker_general";
+
+let blocker = new Blocker([
+    {
+        selector: 'main.c-page-container.c-page-container--has-detailed-content > article > div.c-sticky-container',
+        type: 'big',
+        zIndex: 12002
+    },
+    {
+        selector: 'li.c-grid__item > article.c-teaser-default',
+        type: 'big',
+        zIndex: 12002
+    },
+    {
+        selector: 'li.c-grid__item > article.c-teaser-counter',
+        type: 'big',
+        zIndex: 12002
+    },
+    {
+        selector: 'li.c-grid__item>article.c-teaser-newsticker',
+        type: 'small',
+        zIndex: 12002
+    },
+    {
+        selector: 'div.videoCube',
+        type: 'big',
+        zIndex: 12002
+    },
+    {
+        selector: 'li.jsx-search-result__item',
+        type: 'small'
+    }
+]);
+
+blocker.modifyContent([document]);
+blocker.watchPageForMutations();
+


### PR DESCRIPTION
Added an option for a custom z-index via `zIndex: ...` in the selectorList.
This feature is required for properly displaying the overlay on www.welt.de, which has also been added to the blocker.